### PR TITLE
Remove duplicate code

### DIFF
--- a/sdms.sh
+++ b/sdms.sh
@@ -478,11 +478,6 @@ sdms_ssl() {
             echo "\t}"
             echo ""
         fi
-        echo "\tlocation / {"
-        echo "\t\treturn 301 https://$sdms_domain\$request_uri;"
-        echo "\t}"
-        echo "}"
-        echo ""
         echo "# Serve website"
         echo "server {"
         echo "\tlisten 443 ssl http2;"


### PR DESCRIPTION
Without this change, ./script --ssl example.com produces this: /etc/nginx/sites-enabled/example.com
```
# Redirect HTTP to HTTPS
server {
	listen 80;
	listen [::]:80;
	server_name example.com;

	# Allow ACME challenge validation by Let's Encrypt
	location ^~ /.well-known/acme-challenge/ {
		root /srv/www/example.com;
		default_type text/plain;
	}

	location / {
		return 301 https://example.com$request_uri;
	}
}

	location / {
		return 301 https://example.com$request_uri;
	}
}

# Serve website
...
```
It has duplicate lines.